### PR TITLE
[WIP] Fetch data from 10,000ft

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TENK_USER_ID=user@example.com
+TENK_PASSWORD=really-strong-password

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore .env, as it contains secrets (there .env.example as a template)
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'tenk', git: 'git@github.com:dxw/tenk'
+gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: git@github.com:dxw/tenk
+  revision: 823497ffc755c082e935311875e763bd6d2b475f
+  specs:
+    tenk (0.0.5)
+      activesupport (>= 3)
+      faraday (~> 0.8, < 0.18)
+      hashie (>= 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -75,10 +84,14 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.6)
     diff-lcs (1.3)
+    dotenv (2.7.5)
     erubi (1.9.0)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (4.1.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
@@ -100,6 +113,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.2)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -217,6 +231,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  dotenv
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -228,6 +243,7 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
+  tenk!
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -1,0 +1,31 @@
+require 'dotenv/tasks'
+
+namespace :projects do
+  desc 'Fetch a list of users and their projects from 10,000ft'
+  task fetch: :dotenv do
+    tenk = Tenk.new(
+      user_id: ENV.fetch('TENK_USER_ID'),
+      password: ENV.fetch('TENK_PASSWORD'),
+    )
+
+    projects = Hash.new { |hash, project_id|
+      hash[project_id] = tenk.projects.get(project_id)
+    }
+
+    users = tenk.users.list.data
+
+    users.each do |user|
+      puts user.display_name
+
+      assignments = tenk.users.assignments.list(
+        user.id,
+        from: Date.yesterday,
+        to: Date.tomorrow,
+      ).data
+
+      assignments.each do |assignment|
+        puts "  #{projects[assignment.assignable_id].name};"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a very minimal proof of concept for fetching people and project
data from 10,000ft:

<img width="922" alt="Screenshot 2020-02-12 at 21 04 30" src="https://user-images.githubusercontent.com/74812/74378284-96b86700-4ddd-11ea-8028-36171bf1c324.png">

Copy `.env.example` to `.env` and put real credentials into it --
there's a utilisation-dashboard user in 1Password that can be used here.

I've started with people rather than with projects for a few reasons:

 - it'll help filter out projects without assignments
 - we want people without projects, so would need to do this anyway
 - we'll want to filter for only billable dxw people (ie not admin-only
   accounts and not tradecraft folk), and this is a better starting
   point for that

This doesn't handle pagination, and uses the default 20-items-per-page,
so will only return 20 out of 70 users. The quickest fix for that would
be to use `users.list(per_page: 100)`, which should be good for the rest
of 2020.

This makes a *lot* of calls to the API: one for all the users, then one
for each user, then one for each project. In total that's probably up to
80 API calls -- given the endpoints I'm not sure that's avoidable, so
expect this script to take a long time to execute and try to make it
resilient to intermittent failures (or find a way to break it down into
multiple shorter scripts).

This currently looks for assignments from yesterday until tomorrow --
given we want to treat team membership as a somewhat more stable thing,
it's probably worth starting by looking at the next 4 weeks. That'll
produce multiple projects for several users, so you'll need to find a
way to work out the primary project.

It's not doing anything to filter out non-project assignments (like
leave), which is (I think!) what results in the projects without names
that get shown.

Finally, this script just prints out the data. It instead needs to use
that data to create entities in the database, so they can be used to
render the dashboard.