### PR TITLE
(Chore) Change tenk github url to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,5 +56,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'tenk', git: 'git@github.com:dxw/tenk'
+gem 'tenk', git: 'https://github.com/dxw/tenk'
 gem 'dotenv'


### PR DESCRIPTION
* Because this is a private gem, being pulled during a build, either ssh keys or token
will need to be provided. To prevent needing to add ssh keys, settiing
this to https will allow it to use the provided GitHub token