### PR TITLE
Allow for an X-Frame-Options header

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,12 @@ module TeamDashboard
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+
+    if ENV['IFRAME_ALLOW_ORIGIN'].present?
+      config.action_dispatch.default_headers.merge!(
+        'X-Frame-Options' => "Allow-From #{ENV['IFRAME_ALLOW_ORIGIN']}",
+      )
+    end
   end
 end


### PR DESCRIPTION
This is to allow us to whitelist our dashboard screen orchestrator, so it can load this dashboard in an iframe.

The `IFRAME_ALLOW_ORIGIN` environment variable will need to be set in the production environment.