### PR TITLE
Add scripts to rule them all

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+  echo "==> Installing Ruby…"
+  rbenv install --skip-existing
+  which bundle >/dev/null 2>&1  || {
+    gem install bundler
+    rbenv rehash
+  }
+fi
+
+if [ -f "Gemfile" ]; then
+  echo "==> Installing gem dependencies…"
+  bundle check >/dev/null 2>&1  || {
+    bundle install --quiet --without production
+  }
+fi

--- a/script/server
+++ b/script/server
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# script/server: Launch the application and any extra required processes
+#                locally.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# ensure everything in the app is up to date.
+script/update
+
+test -z "$RACK_ENV" &&
+  RACK_ENV='development'
+
+# boot the app and any other necessary processes.
+bin/rails s

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# script/setup: Set up application for the first time after cloning, or set it
+#               back to the initial first unused state.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+
+echo "==> Setting up DB…"
+# reset database to a fresh state.
+bin/rake db:reset db:create
+
+if [ -z "$RAILS_ENV" ] && [ -z "$RACK_ENV" ]; then
+  # Only things for a development environment will run inside here
+  # Do things that need to be done to the application to set up for the first
+  # time. Or things needed to be run to to reset the application back to first
+  # use experience. These things are scoped to the application's domain.
+  true
+fi
+
+echo "==> App is now ready to go!"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# script/test: Run test suite for application. Optionally pass in a path to an
+#              individual test file to run a single test.
+
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+[ -z "$DEBUG" ] || set -x
+
+RACK_ROOT="$(cd "$(dirname "$0")"/.. && pwd)"
+export RACK_ROOT
+
+if [ "$RAILS_ENV" = "test" ] || [ "$RACK_ENV" = "test" ]; then
+  # if executed and the environment is already set to `test`, then we want a
+  # clean from scratch application. This almost always means a ci environment,
+  # since we set the environment to `test` directly in `script/cibuild`.
+  script/setup
+else
+  # if the environment isn't set to `test`, set it to `test` and update the
+  # application to ensure all dependencies are met as well as any other things
+  # that need to be up to date, like db migrations. The environment not having
+  # already been set to `test` almost always means this is being called on its
+  # own from a `development` environment.
+  export RAILS_ENV="test" RACK_ENV="test"
+
+  script/update
+fi
+
+echo "==> Running tests…"
+
+bundle exec rspec "$@"

--- a/script/update
+++ b/script/update
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# script/update: Update application to run for its current checkout.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+
+echo "==> Updating db…"
+# run all database migrations to ensure everything is up to date.
+bin/rake db:migrate


### PR DESCRIPTION
These scripts simplify the job of setting up, updating and starting this service by doing things like downloading dependencies, running data migrations and starting the server in a consistent way.

As per [RFC 023](https://github.com/dxw/tech-team-rfcs/blob/master/rfc-023-use-scripts-to-rule-them-all.md)