### PR TITLE
Identify projects with 10,000ft ID

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
   has_many :team_members
   validates_presence_of :name
+  validates_presence_of :tenk_id
 end

--- a/db/migrate/20200313120925_store_project_tenk_id.rb
+++ b/db/migrate/20200313120925_store_project_tenk_id.rb
@@ -1,0 +1,5 @@
+class StoreProjectTenkId < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :tenk_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_13_112822) do
+ActiveRecord::Schema.define(version: 2020_03_13_120925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2020_03_13_112822) do
     t.string "client"
     t.string "phase_name"
     t.boolean "archived"
+    t.integer "tenk_id", null: false
   end
 
   create_table "team_members", force: :cascade do |t|

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -33,19 +33,27 @@ namespace :projects do
       ).data
 
       assignments.each do |assignment|
+
+        assignable_project = projects[assignment.assignable_id]
         puts " #{projects[assignment.assignable_id].tags};"
 
+        puts assignment.assignable_id
+        puts assignable_project
 
-        if projects[assignment.assignable_id].name
-          unless projects[assignment.assignable_id].tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
-            project = Project.find_or_create_by!(
-              name: projects[assignment.assignable_id].name,
-              starts_at: projects[assignment.assignable_id].starts_at,
-              ends_at: projects[assignment.assignable_id].ends_at,
-              client: projects[assignment.assignable_id].client,
-              phase_name: projects[assignment.assignable_id].phase_name,
-              archived: projects[assignment.assignable_id].archived
-              )
+        if assignable_project.name
+          unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
+            project = Project.find_or_initialize_by(tenk_id: assignable_project.id)
+
+            project.attributes = {
+              name: assignable_project.name,
+              starts_at: assignable_project.starts_at,
+              ends_at: assignable_project.ends_at,
+              client: assignable_project.client,
+              phase_name: assignable_project.phase_name,
+              archived: assignable_project.archived
+            }
+            project.save!
+
             team_member.project = project
 
           end

--- a/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
+++ b/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'user can see team members within a project', type: 'feature' do
   scenario 'they can see one team member within a given project' do
-    dashboard = Project.create(name: 'Dashboard')
+    dashboard = Project.create(name: 'Dashboard', tenk_id: 1234)
     member = TeamMember.create(first_name: 'Joe', last_name: "Smith", project: dashboard, tenk_id: 1234)
 
     visit '/'

--- a/spec/features/users_can_see_list_of_projects_spec.rb
+++ b/spec/features/users_can_see_list_of_projects_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Users can see a list of projects", type: "feature" do
 
   context "when a single project exist" do
     it "will show a list of projects on the main page" do
-      dashboard = Project.create(name: "Dashboard")
+      dashboard = Project.create(name: "Dashboard", tenk_id: 1234)
       member = TeamMember.create(first_name: 'Joe', last_name: "Smith", project: dashboard, tenk_id: 1234)
 
       visit '/'

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Project, type: :model do
   describe "validations" do
     it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:tenk_id) }
     it { should have_many(:team_members) }
   end
 end


### PR DESCRIPTION
Previously projects were identified using a hash of all details, which meant that any changes would cause new projects to be created in the database.

Projects are now uniquely identified using their ID number from 10,000ft.