### PR TITLE
(70) Regroup project phases as one project

### DIFF
--- a/db/migrate/20200407150339_drop_phase_name_from_project.rb
+++ b/db/migrate/20200407150339_drop_phase_name_from_project.rb
@@ -1,0 +1,5 @@
+class DropPhaseNameFromProject < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :projects, :phase_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_27_144439) do
+ActiveRecord::Schema.define(version: 2020_04_07_150339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 2020_03_27_144439) do
     t.string "starts_at"
     t.string "ends_at"
     t.string "client"
-    t.string "phase_name"
     t.boolean "archived"
     t.integer "tenk_id", null: false
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -39,6 +39,10 @@ namespace :projects do
 
         puts assignment.assignable_id
         puts assignable_project
+        while assignable_project.parent_id
+          puts "#{assignable_project.name} (#{assignable_project.id}), phase of #{assignable_project.parent_id}"
+          assignable_project = projects[assignable_project.parent_id]
+        end
 
         if assignable_project.name
           unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -53,7 +53,6 @@ namespace :projects do
               starts_at: assignable_project.starts_at,
               ends_at: assignable_project.ends_at,
               client: assignable_project.client,
-              phase_name: assignable_project.phase_name,
               archived: assignable_project.archived
             }
             project.save!

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -15,7 +15,7 @@ namespace :projects do
     users = tenk.users.list(per_page: 100).data
 
     users.each do |user|
-      puts user
+      puts user.display_name
       team_member = TeamMember.find_or_initialize_by(tenk_id: user.id)
 
       team_member.attributes = {
@@ -33,16 +33,14 @@ namespace :projects do
       ).data
 
       assignments.each do |assignment|
+        puts "Assignable id: #{assignment.assignable_id}"
 
         assignable_project = projects[assignment.assignable_id]
-        puts " #{projects[assignment.assignable_id].tags};"
-
-        puts assignment.assignable_id
-        puts assignable_project
         while assignable_project.parent_id
           puts "#{assignable_project.name} (#{assignable_project.id}), phase of #{assignable_project.parent_id}"
           assignable_project = projects[assignable_project.parent_id]
         end
+        puts "#{projects[assignable_project.id].tags&.data&.map(&:value)};"
 
         if assignable_project.name
           unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }


### PR DESCRIPTION
For the way we use the team dashboard, we don’t need the different phases of a project.

User assignments in 10kft are done on a project phase basis. Each phase is a project in itself, and the ID of the phase is associated with the user. The phase stores which project it belongs to as a `parent_id` key.

Previously, we were copying the phase - user association as such in our local database, which resulted in the project teams shown on the dashboard being split over project phases.

We are now going up the hierarchy until we find the main project (it will have `parent_id` `nil`), and use the main project to populate the team member assignments in our local database.

This way, the dashboard will show everyone assigned to a project together, regardless of which project phase they are assigned to in 10kft.