### PR TITLE
Define database names for development and test databases

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,9 +7,13 @@ default: &default
 
 development:
   <<: *default
+  database: team_dashboard_development
+
 
 test:
   <<: *default
+  database: team_dashboard_test
+
 
 production:
   <<: *default


### PR DESCRIPTION
This is fixing an connection error where the database wasn't connecting
to the development or test database.
Making the names for each explicit ensures that postgres can connect to the
required databases.