### PR TITLE
Display team members role instead of discipline

### DIFF
--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -5,7 +5,27 @@ class TeamMember < ApplicationRecord
   validates_presence_of :first_name
   validates_uniqueness_of :tenk_id
 
+  ROLES = {
+    "Development" => "Developer",
+    "Delivery" => "Delivery Lead",
+    "Research" => "User Researcher",
+    "Service Design" => "Service Designer",
+    "Design" => "Designer",
+    "Operations Engineering" => "Operations Engineer",
+    "Strategy" => "Strategist",
+    "Technical Architecture" => "Technical Architect",
+    "Product" => "Product Manager"
+  }.freeze
+
   def name
     first_name
+  end
+
+  def job_title
+    if ROLES.key?(discipline)
+      ROLES[discipline]
+    else
+      discipline
+    end
   end
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -13,7 +13,7 @@
               <% end %>
               <dl>
                 <dt><%= team_member.name %></dt>
-                <dd><%= team_member.discipline %></dd>
+                <dd><%= team_member.job_title %></dd>
               </dl>
             </li>
           <% end %>

--- a/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
+++ b/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
@@ -8,10 +8,11 @@ RSpec.feature 'user can see team members within a project', type: 'feature' do
   context "when the team member is assigned to only one project" do
     scenario 'they can see one team member within a given project' do
       dashboard = Project.create(name: 'Dashboard', tenk_id: 1234)
-      member = TeamMember.create(first_name: 'Joe', last_name: "Smith", projects: [dashboard], tenk_id: 1234)
+      member = TeamMember.create(first_name: 'Joe', last_name: "Smith", projects: [dashboard], discipline: "Development", tenk_id: 1234)
 
       visit '/'
       expect(page).to have_content(member.name)
+      expect(page).to have_content(member.job_title)
     end
   end
 

--- a/spec/models/team_member_spec.rb
+++ b/spec/models/team_member_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "pry"
 
 RSpec.describe TeamMember, type: :model do
   subject { TeamMember.create(first_name: "Joe", last_name: "Smith", tenk_id: 1234) }
@@ -14,4 +15,35 @@ RSpec.describe TeamMember, type: :model do
       expect(subject.name).to eq "Joe"
     end
   end
+
+  describe "#job_title" do
+    it "returns the job title matching the discipline" do
+      team_member_one = TeamMember.new(discipline: "Development")
+      team_member_two = TeamMember.new(discipline: "Delivery")
+      team_member_three = TeamMember.new(discipline: "Research")
+      team_member_four = TeamMember.new(discipline: "Service Design")
+      team_member_five = TeamMember.new(discipline: "Design")
+      team_member_six = TeamMember.new(discipline: "Operations Engineering")
+      team_member_seven = TeamMember.new(discipline: "Strategy")
+      team_member_eight = TeamMember.new(discipline: "Technical Architecture")
+      team_member_nine = TeamMember.new(discipline: "Product")
+
+      expect(team_member_one.job_title).to eq "Developer"
+      expect(team_member_two.job_title).to eq "Delivery Lead"
+      expect(team_member_three.job_title).to eq "User Researcher"
+      expect(team_member_four.job_title).to eq "Service Designer"
+      expect(team_member_five.job_title).to eq "Designer"
+      expect(team_member_six.job_title).to eq "Operations Engineer"
+      expect(team_member_seven.job_title).to eq "Strategist"
+      expect(team_member_eight.job_title).to eq "Technical Architect"
+      expect(team_member_nine.job_title).to eq "Product Manager"
+    end
+
+    it "returns 10k ft discipline when theres an unexpected discipline" do
+      team_member_one = TeamMember.new(discipline: "foo")
+
+      expect(team_member_one.job_title).to eq "foo"
+    end
+  end
+
 end


### PR DESCRIPTION
**Changes made:**

The Dashboard now displays team member's roles more accurately.
For example, a developer will now display "Developer" instead of "Development", which had been taken from a team member's discipline data from 10k ft. 