### PR TITLE
Attempt to disambiguate names

### DIFF
--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -18,7 +18,17 @@ class TeamMember < ApplicationRecord
   }.freeze
 
   def name
-    first_name
+    return first_name if last_name.blank? || first_name_unique?
+
+    disambiguated_name
+  end
+
+  def first_name_unique?
+    TeamMember.where(first_name: first_name).count == 1
+  end
+
+  def disambiguated_name
+    "#{first_name} #{last_name[0]}".strip
   end
 
   def job_title

--- a/spec/models/team_member_spec.rb
+++ b/spec/models/team_member_spec.rb
@@ -11,8 +11,24 @@ RSpec.describe TeamMember, type: :model do
   end
 
   describe "#name" do
-    it "returns the first name of the person" do
+    it "returns the first name of the person if their first name is unique within the existing team" do
       expect(subject.name).to eq "Joe"
+    end
+
+    context "for a person whose first name is not unique within the existing team" do
+      before do
+        TeamMember.create(first_name: "Joe", last_name: "Adamson", tenk_id: 1235)
+      end
+
+      it "returns the first name and the initial of the last name if they have one" do
+        expect(subject.name).to eq "Joe S"
+      end
+
+      it "returns the first name of the person if that is their full name" do
+        subject.last_name = ""
+
+        expect(subject.name).to eq "Joe"
+      end
     end
   end
 
@@ -45,5 +61,4 @@ RSpec.describe TeamMember, type: :model do
       expect(team_member_one.job_title).to eq "foo"
     end
   end
-
 end


### PR DESCRIPTION
The old incarnation of the team dashboard used to have a manual way to disambiguate people with the same first names, in order to help people know who’s who.

This commit adds an automatic way to detect when there are people with the same first names in order to append the initial of their last name, if they have one, to the displayed name.

It doesn’t do anything clever if the last names have the same initial. I have considered this an acceptable edge case to have unresolved.