### PR TITLE
Sort teams members alphabetically with delivery leads first

### DIFF
--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -38,4 +38,12 @@ class TeamMember < ApplicationRecord
       discipline
     end
   end
+
+  def delivery_first
+    discipline == "Delivery" ? 0 : 1
+  end
+
+  def self.delivery_first(team_members)
+    team_members.sort_by { |tm| [ tm.delivery_first, tm.name.downcase ] }
+  end
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -4,7 +4,7 @@
       <div class="project" >
         <h2><%= project.name %></h2>
         <ul class="members">
-          <% project.team_members.each do |team_member| %>
+          <% TeamMember.delivery_first(project.team_members).each do |team_member| %>
             <li class="member">
               <% if team_member.thumbnail.present? %>
                 <%= image_tag team_member.thumbnail %>

--- a/spec/models/team_member_spec.rb
+++ b/spec/models/team_member_spec.rb
@@ -61,4 +61,30 @@ RSpec.describe TeamMember, type: :model do
       expect(team_member_one.job_title).to eq "foo"
     end
   end
+
+  describe "#delivery_first" do
+    it "returns 0 for people in the Delivery discipline" do
+      subject.discipline = "Delivery"
+
+      expect(subject.delivery_first).to eq(0)
+    end
+
+    it "returns 1 for people in any other discipline" do
+      expect(subject.delivery_first).to eq(1)
+    end
+  end
+
+  describe ".delivery_first" do
+    it "sorts people in the Delivery discipline first, then everyone by name, case-insensitive" do
+      delivery_lead2 = TeamMember.new(discipline: "Delivery", first_name: "Zaphod")
+      delivery_lead1 = TeamMember.new(discipline: "Delivery", first_name: "Xander")
+      xw = TeamMember.new(first_name: "Xena", last_name: "Warrior")
+      xp = TeamMember.new(first_name: "Xena", last_name: "Princess")
+      a = TeamMember.new(discipline: "Aarghing", first_name: "aardvark")
+      team_members = [xw, a, xp, delivery_lead1, delivery_lead2]
+      delivery_first = [delivery_lead1, delivery_lead2, a, xp, xw]
+
+      expect(TeamMember.delivery_first(team_members)).to eq(delivery_first)
+    end
+  end
 end


### PR DESCRIPTION
Delivery leads are usually the first point of contact when someone wants to find out about a project, so we want to show them first.

In the case of a project with multiple delivery leads, such as GovPress Future, the leads will be sorted by name.

All the other team members will be sorted by name.

Sorting in Rails rather than via database query is OK, because these will always be small numbers of people.