### PR TITLE
Only show active Projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,5 @@
 class ProjectsController < ApplicationController
   def index
-    @projects = Project.all
+    @projects = Project.select(&:active?)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,4 +4,8 @@ class Project < ApplicationRecord
 
   validates_presence_of :name
   validates_presence_of :tenk_id
+
+  def active?
+    !archived && Date.parse(ends_at) >= Date.today
+  end
 end

--- a/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
+++ b/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'user can see team members within a project', type: 'feature' do
 
   context "when the team member is assigned to only one project" do
     scenario 'they can see one team member within a given project' do
-      dashboard = Project.create(name: 'Dashboard', tenk_id: 1234)
+      dashboard = Project.create(name: 'Dashboard', tenk_id: 1234, ends_at: Date.today.to_s)
       member = TeamMember.create(first_name: 'Joe', last_name: "Smith", projects: [dashboard], discipline: "Development", tenk_id: 1234)
 
       visit '/'
@@ -18,8 +18,8 @@ RSpec.feature 'user can see team members within a project', type: 'feature' do
 
   context "when the team member is assigned to more than one project" do
     scenario 'they can see themselves within multiple projects' do
-      dashboard = Project.create(name: 'Dashboard', tenk_id: 1234)
-      beis = Project.create(name: 'Beis', tenk_id: 5678)
+      dashboard = Project.create(name: 'Dashboard', tenk_id: 1234, ends_at: Date.today.to_s)
+      beis = Project.create(name: 'Beis', tenk_id: 5678, ends_at: Date.today.to_s)
       member = TeamMember.create(first_name: 'Joe', last_name: "Smith", projects: [dashboard, beis], tenk_id: 9999)
 
       visit '/'

--- a/spec/features/users_can_see_list_of_projects_spec.rb
+++ b/spec/features/users_can_see_list_of_projects_spec.rb
@@ -5,13 +5,25 @@ RSpec.feature "Users can see a list of projects", type: "feature" do
     page.driver.browser.basic_authorize(ENV.fetch('HTTP_BASIC_USER'), ENV.fetch('HTTP_BASIC_PASSWORD'))
   end
 
-  context "when a single project exist" do
+  context "when a single active project exists" do
     it "will show a list of projects on the main page" do
-      dashboard = Project.create(name: "Dashboard", tenk_id: 1234)
+      dashboard = Project.create(name: "Dashboard", tenk_id: 1234, ends_at: Date.today.to_s)
       member = TeamMember.create(first_name: 'Joe', last_name: "Smith", projects: [dashboard], tenk_id: 1234)
 
-      visit '/'
+      visit "/"
       expect(page).to have_content(dashboard.name)
+    end
+  end
+
+  context "when an inactive project exists" do
+    it "will not be displayed on the main page" do
+      active_project = Project.create(name: "Dashboard", tenk_id: 1234, ends_at: Date.today.to_s)
+      inactive_project = Project.create(name: "Old Project", tenk_id: 5678, ends_at: Date.yesterday.to_s)
+      member = TeamMember.create(first_name: 'Joe', last_name: "Smith", projects: [active_project, inactive_project], tenk_id: 1234)
+
+      visit "/"
+      expect(page).to have_content(active_project.name)
+      expect(page).not_to have_content(inactive_project.name)
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,4 +6,40 @@ RSpec.describe Project, type: :model do
     it { should validate_presence_of(:tenk_id) }
     it { should have_many(:team_members) }
   end
+
+  describe "#active?" do
+    context "when the project is not marked as 'archived'" do
+      context "and the project ends today" do
+        let(:project) { Project.new(ends_at: Date.today.to_s, archived: false) }
+
+        it "is active" do
+          expect(project).to be_active
+        end
+      end
+
+      context "and the project ends after today" do
+        let(:project) { Project.new(ends_at: Date.tomorrow.to_s, archived: false) }
+
+        it "is active" do
+          expect(project).to be_active
+        end
+      end
+
+      context "and the project ended before today" do
+        let(:project) { Project.new(ends_at: Date.yesterday.to_s, archived: false) }
+
+        it "is not active" do
+          expect(project).not_to be_active
+        end
+      end
+    end
+
+    context "when the project is archived" do
+      let(:project) { Project.new(ends_at: Date.today.to_s, archived: true) }
+
+      it "is not active" do
+        expect(project).not_to be_active
+      end
+    end
+  end
 end


### PR DESCRIPTION
"Active" projects are those who fulfill the conditions of:
- the `ends_at` date is after today or today
- not archived

This will stop us having to re-fetch data to remove any inactive projects.