### PR TITLE
Recreate assignments from scratch every time the task is run

### DIFF
--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -43,37 +43,37 @@ class FetchProjects
     team_member
   end
 
-  private def create_assignment(assignment, team_member)
-    puts "Assignable id: #{assignment.assignable_id}"
+  private def create_assignment(tenk_assignment, team_member)
+    puts "Assignable id: #{tenk_assignment.assignable_id}"
 
-    assignable_project = projects[assignment.assignable_id]
-    return unless assignable_project.id
+    tenk_project = projects[tenk_assignment.assignable_id]
+    return unless tenk_project.id
 
-    puts "Project #{assignable_project.name} (#{assignable_project.id})"
+    puts "Project #{tenk_project.name} (#{tenk_project.id})"
 
-    while assignable_project.parent_id
-      assignable_project = projects[assignable_project.parent_id]
-      puts "\tis a phase of project #{assignable_project.name} (#{assignable_project.id})"
+    while tenk_project.parent_id
+      tenk_project = projects[tenk_project.parent_id]
+      puts "\tis a phase of project #{tenk_project.name} (#{tenk_project.id})"
     end
 
-    puts "Tags: #{assignable_project.tags.data.map(&:value)}"
+    puts "Tags: #{tenk_project.tags.data.map(&:value)}"
 
-    unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
-      project = create_or_update_project(assignable_project)
+    unless tenk_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
+      project = create_or_update_project(tenk_project)
 
       team_member.assignments.create(project: project) unless team_member.projects.include?(project)
     end
   end
 
-  private def create_or_update_project(assignable_project)
-    project = Project.find_or_initialize_by(tenk_id: assignable_project.id)
+  private def create_or_update_project(tenk_project)
+    project = Project.find_or_initialize_by(tenk_id: tenk_project.id)
 
     project.attributes = {
-      name: assignable_project.name,
-      starts_at: assignable_project.starts_at,
-      ends_at: assignable_project.ends_at,
-      client: assignable_project.client,
-      archived: assignable_project.archived
+      name: tenk_project.name,
+      starts_at: tenk_project.starts_at,
+      ends_at: tenk_project.ends_at,
+      client: tenk_project.client,
+      archived: tenk_project.archived
     }
     project.save!
     project

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -4,6 +4,8 @@ class FetchProjects
       puts user.display_name
       team_member = create_team_member(user)
 
+      team_member.assignments.destroy_all
+
       assignments = current_user_assignments(user)
       assignments.each do |assignment|
         create_assignment(assignment, team_member)
@@ -60,7 +62,7 @@ class FetchProjects
     unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
       project = create_or_update_project(assignable_project)
 
-      team_member.projects << project unless team_member.projects.include?(project)
+      team_member.assignments.create(project: project) unless team_member.projects.include?(project)
     end
   end
 

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -55,20 +55,25 @@ class FetchProjects
 
     if assignable_project.name
       unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
-        project = Project.find_or_initialize_by(tenk_id: assignable_project.id)
-
-        project.attributes = {
-          name: assignable_project.name,
-          starts_at: assignable_project.starts_at,
-          ends_at: assignable_project.ends_at,
-          client: assignable_project.client,
-          archived: assignable_project.archived
-        }
-        project.save!
+        project = create_or_update_project(assignable_project)
 
         team_member.projects << project unless team_member.projects.include?(project)
       end
     end
+  end
+
+  private def create_or_update_project(assignable_project)
+    project = Project.find_or_initialize_by(tenk_id: assignable_project.id)
+
+    project.attributes = {
+      name: assignable_project.name,
+      starts_at: assignable_project.starts_at,
+      ends_at: assignable_project.ends_at,
+      client: assignable_project.client,
+      archived: assignable_project.archived
+    }
+    project.save!
+    project
   end
 
   private def current_user_assignments(user)

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -46,19 +46,21 @@ class FetchProjects
     puts "Assignable id: #{assignment.assignable_id}"
 
     assignable_project = projects[assignment.assignable_id]
+    return unless assignable_project.id
+
+    puts "Project #{assignable_project.name} (#{assignable_project.id})"
+
     while assignable_project.parent_id
-      puts "#{assignable_project.name} (#{assignable_project.id}), phase of #{assignable_project.parent_id}"
       assignable_project = projects[assignable_project.parent_id]
+      puts "\tis a phase of project #{assignable_project.name} (#{assignable_project.id})"
     end
 
-    puts "#{projects[assignable_project.id].tags&.data&.map(&:value)};"
+    puts "Tags: #{assignable_project.tags.data.map(&:value)}"
 
-    if assignable_project.name
-      unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
-        project = create_or_update_project(assignable_project)
+    unless assignable_project.tags.data.any? { |custom_field| custom_field.has_value?("cyber")  }
+      project = create_or_update_project(assignable_project)
 
-        team_member.projects << project unless team_member.projects.include?(project)
-      end
+      team_member.projects << project unless team_member.projects.include?(project)
     end
   end
 

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -6,7 +6,7 @@ class FetchProjects
 
       assignments = current_user_assignments(user)
       assignments.each do |assignment|
-        create_projects(assignment, team_member)
+        create_assignment(assignment, team_member)
       end
 
       team_member.save!
@@ -42,7 +42,7 @@ class FetchProjects
     team_member
   end
 
-  private def create_projects(assignment, team_member)
+  private def create_assignment(assignment, team_member)
     puts "Assignable id: #{assignment.assignable_id}"
 
     assignable_project = projects[assignment.assignable_id]

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -72,7 +72,7 @@ class FetchProjects
   end
 
   private def current_user_assignments(user)
-    assignments = tenk.users.assignments.list(
+    tenk.users.assignments.list(
       user.id,
       from: Date.yesterday,
       to: Date.tomorrow,

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -10,8 +10,6 @@ class FetchProjects
       assignments.each do |assignment|
         create_assignment(assignment, team_member)
       end
-
-      team_member.save!
     end
   end
 
@@ -41,6 +39,7 @@ class FetchProjects
       thumbnail: user.thumbnail,
       billable: user.billable
     }
+    team_member.save!
     team_member
   end
 

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -4,8 +4,7 @@ class FetchProjects
       puts user.display_name
       team_member = create_team_member(user)
 
-      assignments = get_user_assignment(user)
-
+      assignments = current_user_assignments(user)
       assignments.each do |assignment|
         create_projects(assignment, team_member)
       end
@@ -72,7 +71,7 @@ class FetchProjects
     end
   end
 
-  private def get_user_assignment(user)
+  private def current_user_assignments(user)
     assignments = tenk.users.assignments.list(
       user.id,
       from: Date.yesterday,

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -6,9 +6,9 @@ class FetchProjects
 
       team_member.assignments.destroy_all
 
-      assignments = current_user_assignments(user)
-      assignments.each do |assignment|
-        create_assignment(assignment, team_member)
+      tenk_assignments = current_tenk_assignments(user)
+      tenk_assignments.each do |tenk_assignment|
+        create_assignment(tenk_assignment, team_member)
       end
     end
   end
@@ -79,7 +79,7 @@ class FetchProjects
     project
   end
 
-  private def current_user_assignments(user)
+  private def current_tenk_assignments(user)
     tenk.users.assignments.list(
       user.id,
       from: Date.yesterday,

--- a/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
+++ b/spec/features/user_can_see_a_team_member_in_a_project_spec.rb
@@ -26,5 +26,4 @@ RSpec.feature 'user can see team members within a project', type: 'feature' do
       expect(page).to have_content(member.name).twice
     end
   end
-
 end

--- a/spec/features/users_can_see_list_of_projects_spec.rb
+++ b/spec/features/users_can_see_list_of_projects_spec.rb
@@ -26,5 +26,4 @@ RSpec.feature "Users can see a list of projects", type: "feature" do
       expect(page).not_to have_content(inactive_project.name)
     end
   end
-
 end


### PR DESCRIPTION
https://trello.com/c/EWNHtEC8/102-team-dashboard-seems-to-have-borked-data

In our local schema, assignments are only a many-to-many glue between teams and projects, and do not have time intervals associated with them.

There is no need to keep historical assignments right now, as the dashboard is only meant to give the picture for the current day, so people know who's working on what.

Remove all existing assignments before adding the current ones for the day. This way, older assignments to long-running projects (such as 1st line support) will not accumulate and create confusion.