### PR TITLE
Present recent and upcoming support rotations as a dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 TENK_USER_ID=user@example.com
 TENK_PASSWORD=really-strong-password
+TENK_ID_FOR_SUPPORT=
 HTTP_BASIC_PASSWORD=really-strong-password-2
 HTTP_BASIC_USER=user@example.com

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
 TENK_USER_ID=user@example.com
 TENK_PASSWORD=really-strong-password
+TENK_ID_FOR_SUPPORT=
 HTTP_BASIC_PASSWORD=really-strong-password-2
 HTTP_BASIC_USER=user@example.com

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,13 +18,9 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v1
-      - name: Set Ruby version to use
-        run: |
-          echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.6.5"
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.DXW_TOKEN }}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import url("https://fonts.googleapis.com/css?family=Poppins:400,600,700&display=swap");
 @import url("https://fonts.googleapis.com/css?family=Cardo:400,400i&display=swap");
 @import "normalize";
+@import "dxw-branding";
 
 @function escape-hexcode($colour) {
   @return "%23" + str-slice("" + $colour, 2);
@@ -17,56 +18,15 @@
     no-repeat;
 }
 
-$navy-dark: #17212c;
-$navy: #243746;
-$cream: #f3f1e9;
-$ivory: #f9f8f5;
-
-$grey: #bdbdbd;
-$grey-light: #efefec;
-
-$yellow: #ff9e18;
-$yellow-mid: #ffb259;
-$yellow-light: #fcd672;
-$orange: #ff5c35;
-$orange-mid: #ff8d6b;
-$orange-light: #ffa489;
-$red: #ff595a;
-$red-mid: #ff8189;
-$red-light: #ffb1b9;
-$purple: #69488e;
-$purple-mid: #7473c0;
-$purple-light: #a7a4df;
-$teal: #09615d;
-$teal-mid: #009490;
-$teal-light: #80c7bc;
-$blue: #004876;
-$blue-mid: #009abf;
-$blue-light: #73c3d5;
-
 $dark-colours: (
   $navy-dark $navy $purple $purple-mid $teal $teal-mid $blue $blue-mid
 );
 
-$font-family-serif: "Cardo", -apple-system, serif;
-$font-family-sans-serif: "Poppins", sans-serif;
-
 $system-font-family-serif: $font-family-serif;
 
-$base-font: $font-family-serif;
 $base-line-height: 1.5;
 
-$heading-font-family: $font-family-sans-serif;
 $heading-line-height: 1.35;
-
-// Base site
-$base-font-colour: $navy;
-$body-background-colour: $ivory;
-
-// Links
-$link-colour: $navy;
-$link-colour-light: $ivory;
-
 
 body {
   background-color: $body-background-colour;

--- a/app/assets/stylesheets/dxw-branding.scss
+++ b/app/assets/stylesheets/dxw-branding.scss
@@ -1,0 +1,41 @@
+$navy-dark: #17212c;
+$navy: #243746;
+$cream: #f3f1e9;
+$ivory: #f9f8f5;
+
+$grey: #bdbdbd;
+$grey-light: #efefec;
+
+$yellow: #ff9e18;
+$yellow-mid: #ffb259;
+$yellow-light: #fcd672;
+$orange: #ff5c35;
+$orange-mid: #ff8d6b;
+$orange-light: #ffa489;
+$red: #ff595a;
+$red-mid: #ff8189;
+$red-light: #ffb1b9;
+$purple: #69488e;
+$purple-mid: #7473c0;
+$purple-light: #a7a4df;
+$teal: #09615d;
+$teal-mid: #009490;
+$teal-light: #80c7bc;
+$blue: #004876;
+$blue-mid: #009abf;
+$blue-light: #73c3d5;
+
+$font-family-serif: "Cardo", -apple-system, serif;
+$font-family-sans-serif: "Poppins", sans-serif;
+
+$base-font: $font-family-serif;
+
+$heading-font-family: $font-family-sans-serif;
+
+// Base site
+$base-font-colour: $navy;
+$body-background-colour: $ivory;
+
+// Links
+$link-colour: $navy;
+$link-colour-light: $ivory;

--- a/app/assets/stylesheets/support.scss
+++ b/app/assets/stylesheets/support.scss
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css?family=Cardo:700|Poppins:600,800&display=swap');
+@import "dxw-branding";
+
+body {
+  color: $navy;
+  background-color: $ivory;
+  font-family: $base-font;
+}
+
+h1, table tr th {
+  font-family: $heading-font-family;
+  font-weight: 600;
+}
+
+table {
+  border: 1px solid $navy;
+  border-spacing: 0;
+}
+
+table tr th, table tr td {
+  padding: 10px 10px;
+  border-bottom: 1px solid $navy;
+  border-left: 1px solid $navy;
+}
+
+table tr th {
+  background-color: $yellow-light;
+}
+
+.current {
+  font-weight: bold;
+  background-color: $yellow-light;
+}
+
+.last-month {
+  background-color: $cream;
+}
+
+.historical {
+  background-color: $ivory;
+}
+
+.regular {
+  background-color: $ivory;
+}
+
+.warning {
+  background-color: $red-light;
+}

--- a/app/controllers/support_rotations_controller.rb
+++ b/app/controllers/support_rotations_controller.rb
@@ -1,0 +1,123 @@
+class SupportRotationsController < ApplicationController
+  def index
+    support_days = SupportDay.current
+
+    # Group into week-aspirational intervals
+    combined_days = team_support_days(support_days)
+    batched_days = batched_team_support_days(combined_days)
+    sorted_intervals = create_intervals(batched_days).sort_by(&:start_date)
+
+    # Group by calendar week
+    @intervals = sorted_intervals.group_by(&:calendar_week)
+  end
+
+  private
+
+  def create_intervals(batched_days)
+    batched_days.map { |batch| create_interval(batch) }
+  end
+
+  def create_interval(batch)
+    first_day = batch.first
+    last_day = batch.last
+
+    start_date = first_day.day
+    end_date = last_day.day
+
+    ooh1 = first_day.ooh1_person
+    ooh2 = first_day.ooh2_person
+    ops = first_day.ops_eng
+    dev = first_day.developer
+
+    Interval.new(start_date: start_date,
+                 end_date: end_date,
+                 first_line_dev: dev,
+                 first_line_ops: ops,
+                 first_line_ooh: ooh1,
+                 second_line_ooh: ooh2)
+  end
+
+  Interval = Struct.new(:start_date, :end_date, :first_line_dev, :first_line_ops, :first_line_ooh, :second_line_ooh, keyword_init: true) {
+    def calendar_week
+      start_date.cweek
+    end
+
+    def developer_name
+      first_line_dev.name
+    end
+
+    def ooh1_person_name
+      first_line_ooh.name
+    end
+
+    def ooh2_person_name
+      second_line_ooh.name
+    end
+
+    def ops_eng_name
+      first_line_ops.name
+    end
+
+    def affected_projects
+      in_hours_projects = (first_line_dev.projects + first_line_ops.projects).uniq
+      client_projects = in_hours_projects.select { |p| p.tenk_id != Project::TENK_ID_FOR_SUPPORT }
+      client_projects.select do |project|
+        start_date <= Date.parse(project.ends_at) &&
+          end_date >= Date.parse(project.starts_at)
+      end.map(&:name).join(", ")
+    end
+  }
+
+  def team_support_days(support_days)
+    support_days.group_by(&:date).map do |calendar_day, supp_days|
+      TeamSupportDay.new(day: calendar_day, support_days: supp_days)
+    end
+  end
+
+  # Groups support days into batches with the same combined team
+  # so the start date and end date is a continuous block of time
+  # including weekends
+  def batched_team_support_days(single_days)
+    single_days.chunk_while do |before, after|
+      after.developer == before.developer &&
+        after.ops_eng == before.ops_eng &&
+        after.ooh1_person == before.ooh1_person &&
+        after.ooh2_person == before.ooh2_person &&
+        after.day - before.day <= 3
+    end
+  end
+
+  TeamSupportDay = Struct.new(:day, :support_days, keyword_init: true) {
+    def developer
+      extract_person_by_discipline(support_days, "dev") ||
+        NullPerson.new("Dev TBD")
+    end
+
+    def ops_eng
+      extract_person_by_discipline(support_days, "ops") ||
+        NullPerson.new("Ops TBD")
+    end
+
+    def ooh1_person
+      extract_person_by_discipline(support_days, "ooh1") ||
+        NullPerson.new("OOH1 TBD")
+    end
+
+    def ooh2_person
+      extract_person_by_discipline(support_days, "ooh2") ||
+        NullPerson.new("OOH2 TBD")
+    end
+
+    private
+
+    def extract_person_by_discipline(days, discipline)
+      days.find { |d| d.support_type == discipline }&.team_member
+    end
+  }
+
+  NullPerson = Struct.new(:name) {
+    def projects
+      []
+    end
+  }
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,23 @@
 module ApplicationHelper
+  def row_class_for_interval(start_date, end_date)
+    row_class = "regular"
+
+    if start_date <= Date.today && Date.today <= end_date
+      row_class = "current"
+    elsif start_date < Date.today && start_date >= (Date.today << 1)
+      row_class = "last-month"
+    elsif start_date < Date.today
+      row_class = "historical"
+    end
+
+    row_class
+  end
+
+  def cell_class(person_name)
+    'warning' if person_name.match?(/tbd/i)
+  end
+
+  def prettify_date(date)
+    date.strftime("%a, %d %b %Y")
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,5 @@
 class Project < ApplicationRecord
-  TENK_ID_FOR_SUPPORT = 2360793
+  TENK_ID_FOR_SUPPORT = ENV.fetch("TENK_ID_FOR_SUPPORT")
 
   has_many :assignments
   has_many :team_members, through: :assignments

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,6 @@
 class Project < ApplicationRecord
+  TENK_ID_FOR_SUPPORT = 2360793
+
   has_many :assignments
   has_many :team_members, through: :assignments
 

--- a/app/models/support_day.rb
+++ b/app/models/support_day.rb
@@ -1,4 +1,6 @@
 class SupportDay < ApplicationRecord
+  DXW_SUPPORT_TYPES = %w[dev ops ooh1 ooh2].freeze
+
   belongs_to :team_member
 
   validates_presence_of :date

--- a/app/models/support_day.rb
+++ b/app/models/support_day.rb
@@ -1,0 +1,6 @@
+class SupportDay < ApplicationRecord
+  belongs_to :team_member
+
+  validates_presence_of :date
+  validates_presence_of :support_type
+end

--- a/app/models/support_day.rb
+++ b/app/models/support_day.rb
@@ -1,8 +1,23 @@
 class SupportDay < ApplicationRecord
   DXW_SUPPORT_TYPES = %w[dev ops ooh1 ooh2].freeze
+  MONTHS_IN_THE_PAST_TO_DISPLAY = 2
+  TOTAL_MONTHS_TO_DISPLAY = 12
 
   belongs_to :team_member
 
   validates_presence_of :date
   validates_presence_of :support_type
+
+  default_scope -> { order(date: :asc) }
+
+  scope :current, -> { where("? <= date AND date <= ?", interval_starting_wednesday.first, interval_starting_wednesday.last) }
+
+  def self.interval_starting_wednesday(date = Date.today)
+    interval_start = date << MONTHS_IN_THE_PAST_TO_DISPLAY
+    until interval_start.wednesday?
+      interval_start += 1
+    end
+
+    [interval_start, interval_start + TOTAL_MONTHS_TO_DISPLAY.months]
+  end
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -1,6 +1,7 @@
 class TeamMember < ApplicationRecord
   has_many :assignments
   has_many :projects, through: :assignments
+  has_many :support_days
 
   validates_presence_of :first_name
   validates_uniqueness_of :tenk_id

--- a/app/services/fetch_projects.rb
+++ b/app/services/fetch_projects.rb
@@ -33,9 +33,10 @@ class FetchProjects
   private def create_team_member(user)
     team_member = TeamMember.find_or_initialize_by(tenk_id: user.id)
     team_member.attributes = {
-      first_name: user.first_name,
-      last_name: user.last_name,
-      discipline: user.discipline,
+      first_name: user.first_name.strip,
+      last_name: user.last_name.strip,
+      email: user.email.downcase.strip,
+      discipline: user.discipline.strip,
       thumbnail: user.thumbnail,
       billable: user.billable
     }

--- a/app/services/fetch_support_rotations.rb
+++ b/app/services/fetch_support_rotations.rb
@@ -1,0 +1,38 @@
+require 'support_rota_client'
+
+class FetchSupportRotations
+  def initialize(client: SupportRotaClient.new)
+    @client = client
+  end
+
+  attr_accessor :client
+
+  def call
+    SupportDay::DXW_SUPPORT_TYPES.each do |support_type|
+      json_endpoint = "/v2/#{support_type}/rota.json"
+
+      support_data = JSON.parse(client.get(json_endpoint))
+      support_data.each do |support_datum|
+        date = Date.parse(support_datum.fetch("date"))
+        email = support_datum.dig("person", "email")
+
+        next if email.blank?
+
+        puts "Processing #{date} featuring #{email}..."
+
+        team_member = TeamMember.find_by(email: email)
+
+        if team_member.nil?
+          puts "\t Could not find #{email}"
+          next
+        end
+
+        SupportDay.find_or_initialize_by(
+          team_member_id: team_member.id,
+          date: date,
+          support_type: support_type
+        ).save!
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>TeamDashboard</title>
+    <title><%= content_for?(:html_title) ? yield(:html_title) : "Team Dashboard" %></title>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/support_rotations/index.html.erb
+++ b/app/views/support_rotations/index.html.erb
@@ -1,0 +1,63 @@
+<% content_for(:html_title) { 'Support Rotations Dashboard' } %>
+
+<%= stylesheet_link_tag 'support', media: 'all', 'data-turbolinks-track': 'reload' %>
+
+<body>
+  <h1>Support rotations</h1>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Period starting</th>
+        <th>Period ending</th>
+        <th>Developer</th>
+        <th>Ops engineer</th>
+        <th>OoH (1st line)</th>
+        <th>OoH (2nd line)</th>
+        <th>Affected projects (dev and ops)</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @intervals.each do |_cweek, intervals| %>
+        <%
+          week_start = intervals.first.start_date
+          week_end = intervals.last.end_date
+          row_class = row_class_for_interval(week_start, week_end)
+        %>
+
+        <tr class="<%= row_class %>">
+          <td rowspan="<%= intervals.size %>">
+            <%= prettify_date(week_start) %>
+          </td>
+          <td rowspan="<%= intervals.size %>">
+            <%= prettify_date(week_end) %>
+          </td>
+
+        <% intervals.each do |interval| %>
+
+          <% unless interval == intervals.first %>
+        <tr class="<%= row_class %>">
+          <% end %>
+
+          <td class="<%= cell_class(interval.developer_name) %>">
+            <%= interval.developer_name %>
+          </td>
+          <td class="<%= cell_class(interval.ops_eng_name) %>">
+            <%= interval.ops_eng_name %>
+          </td>
+          <td class="<%= cell_class(interval.ooh1_person_name) %>">
+            <%= interval.ooh1_person_name %>
+          </td>
+          <td class="<%= cell_class(interval.ooh2_person_name) %>">
+            <%= interval.ooh2_person_name %>
+          </td>
+          <td>
+            <%= interval.affected_projects %>
+          </td>
+        </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root 'projects#index'
 
+  resources :support_rotations, only: [:index]
+
   get "/check", to: proc { [200, {}, ["OK"]] }
 end

--- a/db/migrate/20200610172512_add_email_to_team_member.rb
+++ b/db/migrate/20200610172512_add_email_to_team_member.rb
@@ -1,0 +1,6 @@
+class AddEmailToTeamMember < ActiveRecord::Migration[6.0]
+  def change
+    add_column :team_members, :email, :string
+    add_index :team_members, :email
+  end
+end

--- a/db/migrate/20200610175434_create_support_days.rb
+++ b/db/migrate/20200610175434_create_support_days.rb
@@ -1,0 +1,9 @@
+class CreateSupportDays < ActiveRecord::Migration[6.0]
+  def change
+    create_table :support_days, id: :uuid do |t|
+      t.belongs_to :team_member, index: true, null: false
+      t.date :date
+      t.string :support_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_10_172512) do
+ActiveRecord::Schema.define(version: 2020_06_10_175434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -33,6 +33,13 @@ ActiveRecord::Schema.define(version: 2020_06_10_172512) do
     t.string "client"
     t.boolean "archived"
     t.integer "tenk_id", null: false
+  end
+
+  create_table "support_days", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.bigint "team_member_id", null: false
+    t.date "date"
+    t.string "support_type"
+    t.index ["team_member_id"], name: "index_support_days_on_team_member_id"
   end
 
   create_table "team_members", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_07_150339) do
+ActiveRecord::Schema.define(version: 2020_06_10_172512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -43,6 +43,8 @@ ActiveRecord::Schema.define(version: 2020_04_07_150339) do
     t.boolean "billable"
     t.string "first_name"
     t.string "last_name"
+    t.string "email"
+    t.index ["email"], name: "index_team_members_on_email"
     t.index ["project_id"], name: "index_team_members_on_project_id"
   end
 

--- a/lib/support_rota_client.rb
+++ b/lib/support_rota_client.rb
@@ -1,0 +1,18 @@
+class SupportRotaClient
+  def initialize
+    @api_base = "https://dxw-support-rota.herokuapp.com"
+  end
+
+  attr_reader :api_base
+
+  def connection
+    Faraday.new(url: api_base) do |faraday|
+      faraday.request :retry, max: 5, interval: 0.5, exceptions: [Faraday::ConnectionFailed, Errno::ETIMEDOUT, Timeout::Error]
+      faraday.adapter Faraday.default_adapter
+    end
+  end
+
+  def get(endpoint)
+    connection.get(endpoint).body
+  end
+end

--- a/lib/tasks/support_rotations.rake
+++ b/lib/tasks/support_rotations.rake
@@ -1,0 +1,10 @@
+require 'dotenv/tasks'
+require 'support_rota_client'
+
+namespace :support_rotations do
+  desc "Fetch from dxw-support-rota directly into SupportDay"
+  task fetch_all_support_lines: [:dotenv, :environment] do
+    SupportDay.destroy_all
+    FetchSupportRotations.new.call
+  end
+end

--- a/spec/features/users_can_see_the_table_of_support_rotations_spec.rb
+++ b/spec/features/users_can_see_the_table_of_support_rotations_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature "Users can see the table of support rotations", type: "feature" do
+  before do
+    page.driver.browser.basic_authorize(ENV.fetch('HTTP_BASIC_USER'), ENV.fetch('HTTP_BASIC_PASSWORD'))
+  end
+
+  it "will show the people assigned to support rotations and the affected client projects" do
+    client1 = Project.create(name: "Client One", tenk_id: 123, starts_at: 1.month.ago, ends_at: Date.today.to_s)
+    team_member = TeamMember.create(first_name: "Jay", projects: [client1], tenk_id: 1234)
+
+    past_day = team_member.support_days.create(date: 1.month.ago, support_type: "dev")
+    current_day = team_member.support_days.create(date: Date.today, support_type: "dev")
+    future_day = team_member.support_days.create(date: 2.months.from_now, support_type: "dev")
+
+    dev_day = team_member.support_days.create(date: 2.months.from_now, support_type: "dev")
+    ops_day = team_member.support_days.create(date: 2.months.from_now, support_type: "ops")
+    ooh1_day = team_member.support_days.create(date: 2.months.from_now, support_type: "ooh1")
+    ooh2_day = team_member.support_days.create(date: 2.months.from_now, support_type: "ooh2")
+
+    visit "/support_rotations"
+
+    expect(page).to have_content("Support rotations")
+    expect(page).to have_content("Client One")
+  end
+end

--- a/spec/models/support_day_spec.rb
+++ b/spec/models/support_day_spec.rb
@@ -5,4 +5,34 @@ RSpec.describe SupportDay, type: :model do
     it { should validate_presence_of(:date) }
     it { should validate_presence_of(:support_type) }
   end
+
+  describe ".current" do
+    it "returns the rolling interval of support days" do
+      team_member = TeamMember.create(first_name: "Jay", tenk_id: 1)
+      current_day = team_member.support_days.create(date: Date.today, support_type: "ops")
+      historical_day = team_member.support_days.create(date: 3.months.ago, support_type: "ops")
+
+      expect(SupportDay.current).to include(current_day)
+      expect(SupportDay.current).not_to include(historical_day)
+    end
+  end
+
+  describe ".interval_starting_wednesday" do
+    let(:date) { Date.new(2020, 9, 14) }
+    let(:interval) { SupportDay.interval_starting_wednesday(date) }
+
+    it "always starts on a Wednesday" do
+      (date..(date + 6)).each do |d|
+        expect(SupportDay.interval_starting_wednesday(d).first.wednesday?).to be_truthy
+      end
+    end
+
+    it "starts MONTHS_IN_THE_PAST_TO_DISPLAY months ago" do
+      expect(interval.first.to_s).to eq("2020-07-15")
+    end
+
+    it "ends TOTAL_MONTHS_TO_DISPLAY later from the start date" do
+      expect(interval.last.to_s).to eq("2021-07-15")
+    end
+  end
 end

--- a/spec/models/support_day_spec.rb
+++ b/spec/models/support_day_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe SupportDay, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:date) }
+    it { should validate_presence_of(:support_type) }
+  end
+end


### PR DESCRIPTION
Includes all types of support that a dxw tech team member can be scheduled to do via OpsGenie: first line development, first line ops, first line out of hours, and second line out of hours.

Story with user needs: https://trello.com/c/1rK8TNoi/66-provide-a-user-friendly-visualisation-of-the-upcoming-support-rotations
