### PR TITLE
Remove set-env command from CI setup

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,13 +18,9 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v1
-      - name: Set Ruby version to use
-        run: |
-          echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "2.6.5"
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.DXW_TOKEN }}


### PR DESCRIPTION
`setup-ruby` uses the version specified in `.ruby-version`.

Recently, running the build on GH actions started failing with the error:

"The `set-env` command is disabled"

Other, more active projects, have already dealt with this, so I'm attempting to deal with it in a similar manner.