### PR TITLE
Don’t show the 10kft support project as “affected”

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 TENK_USER_ID=user@example.com
 TENK_PASSWORD=really-strong-password
-TENK_ID_FOR_SUPPORT=
+TENK_ID_FOR_SUPPORT=101
 HTTP_BASIC_PASSWORD=really-strong-password-2
 HTTP_BASIC_USER=user@example.com

--- a/app/controllers/support_rotations_controller.rb
+++ b/app/controllers/support_rotations_controller.rb
@@ -60,7 +60,7 @@ class SupportRotationsController < ApplicationController
 
     def affected_projects
       in_hours_projects = (first_line_dev.projects + first_line_ops.projects).uniq
-      client_projects = in_hours_projects.select { |p| p.tenk_id != Project::TENK_ID_FOR_SUPPORT }
+      client_projects = in_hours_projects.select { |p| p.tenk_id.to_s != Project::TENK_ID_FOR_SUPPORT }
       client_projects.select do |project|
         start_date <= Date.parse(project.ends_at) &&
           end_date >= Date.parse(project.starts_at)

--- a/spec/features/users_can_see_the_table_of_support_rotations_spec.rb
+++ b/spec/features/users_can_see_the_table_of_support_rotations_spec.rb
@@ -6,8 +6,9 @@ RSpec.feature "Users can see the table of support rotations", type: "feature" do
   end
 
   it "will show the people assigned to support rotations and the affected client projects" do
+    support_project = Project.create(name: "1st line support", tenk_id: ENV.fetch("TENK_ID_FOR_SUPPORT", nil))
     client1 = Project.create(name: "Client One", tenk_id: 123, starts_at: 1.month.ago, ends_at: Date.today.to_s)
-    team_member = TeamMember.create(first_name: "Jay", projects: [client1], tenk_id: 1234)
+    team_member = TeamMember.create(first_name: "Jay", projects: [client1, support_project], tenk_id: 1234)
 
     past_day = team_member.support_days.create(date: 1.month.ago, support_type: "dev")
     current_day = team_member.support_days.create(date: Date.today, support_type: "dev")
@@ -22,5 +23,6 @@ RSpec.feature "Users can see the table of support rotations", type: "feature" do
 
     expect(page).to have_content("Support rotations")
     expect(page).to have_content("Client One")
+    expect(page).not_to have_content("1st line support")
   end
 end


### PR DESCRIPTION
Bug:
<img width="823" alt="Screenshot 2021-02-05 at 15 32 39" src="https://user-images.githubusercontent.com/579522/107053981-6e343480-67c7-11eb-9bae-da31d514e5ca.png">

The support project itself should not be listed as "Affected projects", since that refers to client projects affected by someone being on 1st line support.

When the 10kft ID for the support project was moved from being a constant to being an env var, we kept comparing it to other project IDs without type conversion.

However, env vars are strings, and project IDs are integers.

Convert to string before comparing.